### PR TITLE
feat(api): add an optional parameter to log additional values

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Logger.error('Unable to parse the JSON response from the authentication API');
 // forced to shut down, use Logger.fatal:
 Logger.fatal('Unhandled exception from the file system');
 // [2021-01-21T07:51:43:0088Z] FATAL: Unhandled exception from the file system
+
+// Optionally, a record of strings, numbers, and booleans (null and undefined
+// are also accepted) can be provided and appended to the log.
+Logger.info('Request has completed', { requestId: 'abc123', httpStatus: 200 });
+// [2021-01-21T07:51:43:0083Z] INFO: Request has completed requestId="abc123" httpStatus=200
 ```
 
 ## Versioning

--- a/docs/api.md
+++ b/docs/api.md
@@ -80,6 +80,26 @@ Here is an example of a log with multiple entries:
 [2021-01-21T07:51:43:0088Z] FATAL: Unhandled exception from the file system
 ```
 
+## Additional log values
+
+It can be useful to append values to a log in addition to the message. This can easily be done with `eleventh` by supplying a record with string keys and values which are strings, numbers, or booleans (`null` and `undefined` are also accepted).
+
+Here is an example of passing some additional log values:
+
+```javascript
+import Logger from 'eleventh';
+
+Logger.info('An email has been sent', {
+  from: 'alice@gmail.com',
+  to: 'bob@gmail.com',
+  title: 'Hello, world!',
+  duration: 42,
+  success: true,
+});
+
+// [2021-01-21T07:51:43:0076Z] INFO: An email has been sent from="alice@gmail.com" to="bob@gmail.com" title="Hello, world!" duration=42 success=true
+```
+
 # Subscribing to log entries
 
 If you would like to subscribe to your application's logs directly rather than listening to the standard output, you can use the `subscribe` method:

--- a/src/escapeReservedCharacters.ts
+++ b/src/escapeReservedCharacters.ts
@@ -1,0 +1,6 @@
+export default (value: string): string => (
+  value
+    .replace(/:/ug, '\\:') // replace : with \:
+    .replace(/\[/ug, '\\[') // replace [ with \[
+    .replace(/\]/ug, '\\]') // replace ] with \]
+);

--- a/src/stringifyValues.ts
+++ b/src/stringifyValues.ts
@@ -1,0 +1,15 @@
+import escapeNewlines from './escapeNewlines';
+
+type SafelyStringifiableValue = string | number | boolean | null | undefined;
+
+export type SafelyStringifiableValues = (
+  Record<string, SafelyStringifiableValue>
+);
+
+export default (values: SafelyStringifiableValues): string => (
+  Object
+    .keys(values)
+    .reduce((result, key) => (
+      `${result} ${escapeNewlines(key)}=${JSON.stringify(values[key])}`
+    ), '')
+);


### PR DESCRIPTION
Optionally, a record of strings, numbers, and booleans (`null` and `undefined` are also accepted) can be provided and appended to the log.

```javascript
Logger.info('Request has completed', { requestId: 'abc123', httpStatus: 200 });
// [2021-01-21T07:51:43:0083Z] INFO: Request has completed requestId="abc123" httpStatus=200
```