### PR TITLE
fix: make the additional values parameter optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ const subscribe: Subscribe = (subscription) => {
 
 const output = (logLevel: LogLevel) => (
   message: string,
-  values: SafelyStringifiableValues,
+  values: SafelyStringifiableValues = {},
 ): void => {
   if (!shouldLog(logLevel)) {
     return;


### PR DESCRIPTION
Make the optional values parameter `{}` by default.