### PR TITLE
Fix zero-based month in UTC timestamp formatting

### DIFF
--- a/src/getCurrentTime.ts
+++ b/src/getCurrentTime.ts
@@ -1,7 +1,7 @@
 export default (): string => {
   const now = new Date();
   const year = now.getUTCFullYear();
-  const month = now.getUTCMonth().toString().padStart(2, '0');
+  const month = (now.getUTCMonth() + 1).toString().padStart(2, '0');
   const day = now.getUTCDate().toString().padStart(2, '0');
   const hours = now.getUTCHours().toString().padStart(2, '0');
   const minutes = now.getUTCMinutes().toString().padStart(2, '0');


### PR DESCRIPTION
This PR fixes the issue where the `getUTCMonth` function returns a zero-based month value, causing the formatted timestamp to display the wrong month. The month value is now incremented by 1 before converting to a string, thus ensuring the timestamp reflects the correct human-readable month (1-12).